### PR TITLE
FileChooser implementation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,11 @@
+install_data(
+    'pantheon.portal',
+    install_dir: join_paths(get_option('datadir'), 'xdg-desktop-portal', 'portals')
+)
+
+configure_file(
+    input: meson.project_name() + '.service.in',
+    output: meson.project_name() + '.service',
+    configuration: conf_data,
+    install_dir: systemd_dep.get_pkgconfig_variable('systemduserunitdir')
+)

--- a/data/xdg-desktop-portal-pantheon.service.in
+++ b/data/xdg-desktop-portal-pantheon.service.in
@@ -4,4 +4,4 @@ Description=Portal service (Pantheon implementation)
 [Service]
 Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.pantheon
-ExecStart=@libexecdir@/xdg-desktop-portal-pantheon
+ExecStart=@LIBEXECDIR@/xdg-desktop-portal-pantheon

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,30 @@
 project('xdg-desktop-portal-pantheon', 'c', 'vala')
 
+add_project_arguments(
+    ['--vapidir', join_paths(meson.current_source_dir(), 'vapi')],
+    language: 'vala'
+)
+
+systemd_dep = dependency('systemd')
+vala = meson.get_compiler('vala')
+
 glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')
 gio_dep = dependency('gio-2.0')
 gtk_dep = dependency('gtk+-3.0')
+
+
+posix_dep = vala.find_library('posix')
+unity_dep = dependency('unity')
+
+pantheon_file_core_c_dep = vala.find_library('pantheon-files-core-C', dirs: join_paths(meson.current_source_dir(), 'vapi'))
+pantheon_files_lib_dep = dependency('pantheon-files')
+pantheon_files_core_lib_dep = dependency('pantheon-files-core')
+pantheon_files_widgets_lib_dep = dependency('pantheon-files-widgets')
+granite_dep = dependency('granite')
+
+conf_data = configuration_data()
+conf_data.set('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
 
 subdir('data')
 subdir('src')

--- a/src/XdgDesktopPortalPantheon.vala
+++ b/src/XdgDesktopPortalPantheon.vala
@@ -30,6 +30,17 @@ private const GLib.OptionEntry[] options = {
     { null }
 };
 
+void on_bus_acquired (DBusConnection conn, string n) {
+    try {
+        const string name = "/org/freedesktop/portal/desktop";
+        var object = new FileChooser ();
+        conn.register_object (name, object);
+        debug ("FileChooser object registered with dbus connection name %s", name);
+    } catch (IOError e) {
+        error ("Could not register FileChooser service");
+    }   
+}
+
 int main (string[] args) {
     GLib.Intl.setlocale (GLib.LocaleCategory.ALL, "");
     /*GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
@@ -82,7 +93,7 @@ int main (string[] args) {
         GLib.BusType.SESSION,
         "org.freedesktop.impl.portal.desktop.pantheon",
         GLib.BusNameOwnerFlags.ALLOW_REPLACEMENT,
-        () => {},
+        on_bus_acquired,
         () => {},
         () => {}
     );

--- a/src/filechooser-portal/FileChooser.vala
+++ b/src/filechooser-portal/FileChooser.vala
@@ -1,0 +1,92 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+enum ResponseType {
+    SUCCESS = 0,
+    CANCELLED,
+    ENDED
+}
+
+public struct FileRequestResponse {
+    uint32 response;
+    HashTable<string, Variant> results;
+}
+
+[DBus (name = "org.freedesktop.impl.portal.FileChooser")]
+public class FileChooser : Object {
+    public FileChooser () {
+        var mapp = new Marlin.Application ();
+        mapp.initialize ();
+
+        var app = new Application ("io.elementary.files-portal", ApplicationFlags.NON_UNIQUE);
+        Application.set_default (app);
+    }
+
+    public void open_file (ObjectPath handle, string app_id, string parent_window, string title,
+                        HashTable<string, Variant> options, out uint32 response, out HashTable<string, Variant> results) throws Error {
+        results = show_dialog (parent_window, title, options, out response);
+    }
+
+    public void save_file (ObjectPath handle, string app_id, string parent_window, string title,
+                        HashTable<string, Variant> options, out uint32 response, out HashTable<string, Variant> results) throws Error {
+        results = show_dialog (parent_window, title, options, out response);
+    }
+
+
+    private static HashTable<string, Variant> show_dialog (string parent_window, string title,
+                                                        HashTable<string, Variant> options,
+                                                        out uint32 response) {
+
+        uint32 _resp = ResponseType.SUCCESS;
+        var results = new HashTable<string, Variant> (str_hash, null);                                       
+        var loop = new MainLoop ();
+
+        var dialog = new FileChooserDialog (title);
+
+        ulong destroy_id = dialog.destroy.connect (() => {
+            results.insert ("uris", create_with_selection (new List<GOF.File> ()));
+            _resp = ResponseType.CANCELLED;
+
+            loop.quit ();
+        });
+
+        dialog.selected.connect ((selection) => {
+            results.insert ("uris", create_with_selection (selection));
+            loop.quit ();
+
+            dialog.disconnect (destroy_id);
+            dialog.destroy ();
+        });
+
+        dialog.show_all ();
+
+        loop.run ();
+
+        response = _resp;
+        return results;
+    }
+
+    private static Variant create_with_selection (List<GOF.File> selection) {
+        var builder = new VariantBuilder (VariantType.STRING_ARRAY);
+        Variant[] uris = {};
+        foreach (var file in selection) {
+            builder.add ("s", file.uri);
+        }
+
+        return builder.end ();
+    }
+}

--- a/src/filechooser-portal/FileChooser.vala
+++ b/src/filechooser-portal/FileChooser.vala
@@ -82,7 +82,6 @@ public class FileChooser : Object {
 
     private static Variant create_with_selection (List<GOF.File> selection) {
         var builder = new VariantBuilder (VariantType.STRING_ARRAY);
-        Variant[] uris = {};
         foreach (var file in selection) {
             builder.add ("s", file.uri);
         }

--- a/src/filechooser-portal/FileChooserDialog.vala
+++ b/src/filechooser-portal/FileChooserDialog.vala
@@ -1,0 +1,195 @@
+/*-
+ * Copyright (c) 2017-2018 elementary LLC (http://launchpad.net/elementary)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335 USA.
+ *
+ * Authored by: Adam Bieńkowski <donadigos159@gmail.com>
+ */
+
+public class FileChooserDialog : Gtk.Dialog {
+    public bool is_destroyed { get; set; default = false; }
+    public signal void selected (List<GOF.File> selection);
+
+    private Marlin.View.ViewContainer view_container;
+    private Marlin.View.Chrome.TopMenu top_menu;
+    private SimpleAction view_mode_action;
+
+    private static Settings? settings;
+    static construct {
+        settings = new Settings ("io.elementary.files.preferences");
+    }
+
+    construct {
+        var home_file = File.new_for_path (Environment.get_home_dir ());
+
+        view_container = new Marlin.View.ViewContainer (null);
+        view_container.expand = true;
+        view_container.add_view (Marlin.ViewMode.ICON, home_file);
+        view_container.loading.connect ((is_loading) => {
+            update_top_menu ();
+        });
+
+        view_container.active.connect (() => {
+            update_top_menu ();
+        });
+
+        view_container.slot.handle_activate_selected_items.connect (handle_activate_selected_items);
+
+        view_mode_action = new SimpleAction ("view-mode", VariantType.STRING);
+        view_mode_action.activate.connect (action_view_mode);
+
+        var view_switcher = new Marlin.View.Chrome.ViewSwitcher (view_mode_action);
+        view_switcher.mode = settings.get_enum ("default-viewmode");
+
+        top_menu = new Marlin.View.Chrome.TopMenu (view_switcher);
+        top_menu.location_bar.set_display_path (home_file.get_path ());
+        top_menu.location_bar.path_change_request.connect ((path, flag) => {
+            uri_path_change_request (path, flag);
+        });
+
+        top_menu.forward.connect (() => {view_container.go_forward ();});
+        top_menu.back.connect (() => {view_container.go_back ();});
+        //  top_menu.escape.connect (grab_focus);
+        top_menu.path_change_request.connect ((loc, flag) => {
+            view_container.is_frozen = false;
+            uri_path_change_request (loc, flag);
+        });
+        //  top_menu.reload_request.connect (action_reload);
+        top_menu.focus_location_request.connect ((loc) => {
+            view_container.focus_location_if_in_current_directory (loc, true);
+        });
+        top_menu.focus_in_event.connect (() => {
+            view_container.is_frozen = true;
+            return true;
+        });
+        top_menu.focus_out_event.connect (() => {
+            view_container.is_frozen = false;
+            return true;
+        });
+
+        var folder_button = new Gtk.Button.from_icon_name ("folder-new", Gtk.IconSize.LARGE_TOOLBAR);
+        folder_button.clicked.connect (() => {
+            view_container.slot.new_folder ();
+        });
+
+        unowned Gtk.Box content_area = get_content_area ();
+
+
+        var sidebar = new Marlin.Places.Sidebar (null, false);
+        sidebar.path_change_request.connect (uri_path_change_request);
+
+        var lside_pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        lside_pane.position = settings.get_int ("sidebar-width");
+        lside_pane.show ();
+        lside_pane.pack1 (sidebar, false, false);
+        lside_pane.pack2 (view_container, true, false);
+
+        content_area.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+        content_area.add (lside_pane);
+        content_area.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+
+        var open_button = new Gtk.Button.with_label ("Open");
+        open_button.clicked.connect (on_open_button_clicked);
+
+        var cancel_button = new Gtk.Button.with_label ("Cancel");
+        cancel_button.clicked.connect (() => destroy ());
+
+        var bottom_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
+        bottom_box.spacing = 6;
+        bottom_box.margin = 6;
+        bottom_box.halign = Gtk.Align.END;
+        bottom_box.pack_end (cancel_button);
+        bottom_box.pack_end (open_button);
+
+        content_area.add (bottom_box);
+        top_menu.pack_end (folder_button);
+
+        set_titlebar (top_menu);
+        set_default_size (700, 450);
+    }
+
+    public FileChooserDialog (string title) {
+        Object (title: title, use_header_bar: 1);
+    }
+
+    public override void destroy () {
+        is_destroyed = true;
+        base.destroy ();
+    }
+
+    private void uri_path_change_request (string uri, Marlin.OpenFlag flag = Marlin.OpenFlag.DEFAULT) {
+        string path = PF.FileUtils.sanitize_path (uri, null);
+        if (path.length > 0) {
+            var f = File.new_for_uri (PF.FileUtils.escape_uri (path));
+            view_container.focus_location (f);
+            top_menu.update_location_bar (uri);
+        }
+    }
+
+    private void update_top_menu () {
+        top_menu.set_back_menu (view_container.get_go_back_path_list ());
+        top_menu.set_forward_menu (view_container.get_go_forward_path_list ());
+        top_menu.can_go_back = view_container.can_go_back;
+        top_menu.can_go_forward = (view_container.can_show_folder && view_container.can_go_forward);
+        top_menu.working = view_container.is_loading;
+    
+        top_menu.update_location_bar (view_container.location.get_uri ());    
+    }
+
+    private void action_view_mode (GLib.Variant? param) {
+        string mode_string = param.get_string ();
+        Marlin.ViewMode mode = Marlin.ViewMode.MILLER_COLUMNS;
+        switch (mode_string) {
+            case "ICON":
+                mode = Marlin.ViewMode.ICON;
+                break;
+
+            case "LIST":
+                mode = Marlin.ViewMode.LIST;
+                break;
+
+            case "MILLER":
+                mode = Marlin.ViewMode.MILLER_COLUMNS;
+                break;
+
+            default:
+                break;
+        }
+
+        // We change the view and the slot gets recreated, therefore
+        // ww have to reconnect to it
+
+        view_container.slot.handle_activate_selected_items.disconnect (handle_activate_selected_items);
+        view_container.change_view_mode (mode);
+        view_container.slot.handle_activate_selected_items.connect (handle_activate_selected_items);
+    }
+
+    private void on_open_button_clicked () {
+        unowned List<GOF.File> selected = view_container.slot.get_selected_files ();
+        handle_activate_selected_items (selected);
+    }
+
+    private bool handle_activate_selected_items (List<GOF.File> selection) {
+        foreach (GOF.File file in selection) {
+            if (!file.is_folder ()) {
+                selected (selection);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/filechooser-portal/main.vala
+++ b/src/filechooser-portal/main.vala
@@ -1,0 +1,46 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void on_file_chooser_bus_acquired (DBusConnection conn, string n) {
+    try {
+        string name = "/org/freedesktop/portal/desktop";
+        var object = new FileChooser (conn);
+        conn.register_object (name, object);
+        debug ("FileChooser object registered with dbus connection name %s", name);
+    } catch (IOError e) {
+        error ("Could not register FileChooser service");
+    }   
+}
+
+extern void exit (int exit_code);
+
+void on_name_lost (DBusConnection connection, string name) {
+    critical ("Name %s was not acquired", name);
+    exit (-1);
+}
+
+
+void main (string[] args) {
+    Gtk.init (ref args);
+
+    Bus.own_name (BusType.SESSION, "org.freedesktop.portal.Desktop", BusNameOwnerFlags.REPLACE,
+        on_file_chooser_bus_acquired,
+        () => {},
+        on_name_lost);
+
+    Gtk.main ();
+}

--- a/src/filechooser-portal/meson.build
+++ b/src/filechooser-portal/meson.build
@@ -1,0 +1,15 @@
+pantheon_files_lib_dep = dependency('pantheon-files')
+
+executable(
+    meson.project_name() + '-portal',
+    # 'main.vala',
+    'FileChooser.vala',
+    'FileChooserDialog.vala',
+    'Request.vala',
+
+    dependencies : [
+        pantheon_files_lib_dep,
+    ],
+
+    install: true,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,11 +1,20 @@
 executable(
     meson.project_name(),
     'XdgDesktopPortalPantheon.vala',
+    'filechooser-portal/FileChooser.vala',
+    'filechooser-portal/FileChooserDialog.vala',
     dependencies: [
         glib_dep,
         gobject_dep,
         gio_dep,
-        gtk_dep
+        gtk_dep,
+        granite_dep,
+        pantheon_files_lib_dep,
+        pantheon_file_core_c_dep,
+        pantheon_files_widgets_lib_dep,
+        pantheon_files_core_lib_dep,
+        posix_dep,
+        unity_dep
     ],
     install: true,
     install_dir: get_option('libexecdir'),

--- a/vapi/pantheon-files-core-C.vapi
+++ b/vapi/pantheon-files-core-C.vapi
@@ -1,0 +1,141 @@
+using GLib;
+
+[CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
+namespace Config {
+    public const string GETTEXT_PACKAGE;
+    public const string UI_DIR;
+    public const string VERSION;
+    public const string PLUGIN_DIR;
+    public const string TESTDATA_DIR;
+    public const string APP_NAME;
+    public const string TERMINAL_NAME;
+}
+
+[CCode (cprefix = "FM", lower_case_cprefix = "fm_", cheader_filename = "fm-list-model.h")]
+namespace FM
+{
+    public class ListModel : GLib.Object, Gtk.TreeModel, Gtk.TreeDragDest, Gtk.TreeSortable
+    {
+        [CCode (cprefix = "FM_LIST_MODEL_", cheader_filename = "fm-list-model.h")]
+        public enum ColumnID {
+            FILE_COLUMN,
+            COLOR,
+            PIXBUF,
+            FILENAME,
+            SIZE,
+            SCALE_FACTOR,
+            TYPE,
+            MODIFIED,
+            NUM_COLUMNS
+        }
+
+        public bool load_subdirectory(Gtk.TreePath path, out GOF.Directory.Async dir);
+        public bool unload_subdirectory(Gtk.TreeIter iter);
+        public void add_file(GOF.File file, GOF.Directory.Async dir);
+        public bool remove_file (GOF.File file, GOF.Directory.Async dir);
+        public void file_changed (GOF.File file, GOF.Directory.Async dir);
+        public GOF.File? file_for_path (Gtk.TreePath path);
+        public static GLib.Type get_type ();
+        public bool get_first_iter_for_file (GOF.File file, out Gtk.TreeIter iter);
+        public bool get_tree_iter_from_file (GOF.File file, GOF.Directory.Async directory, out Gtk.TreeIter iter);
+        public bool get_directory_file (Gtk.TreePath path, out unowned GOF.Directory.Async directory, out unowned GOF.File file);
+        public GOF.File? file_for_iter (Gtk.TreeIter iter);
+        public void clear ();
+        public void set_should_sort_directories_first (bool directories_first);
+        public signal void subdirectory_unloaded (GOF.Directory.Async directory);
+        public static string get_string_from_column_id (FM.ListModel.ColumnID id);
+        public static FM.ListModel.ColumnID get_column_id_from_string (string colstr);
+    }
+}
+
+
+namespace Marlin {
+    [CCode (cprefix = "MarlinFileOperations", lower_case_cprefix = "marlin_file_operations_", cheader_filename = "marlin-file-operations.h")]
+    namespace FileOperations {
+        static void new_folder(Gtk.Widget? parent_view, Gdk.Point? target_point, GLib.File file,Marlin.CreateCallback? create_callback = null);
+        static void mount_volume (GLib.Volume volume, Gtk.Window? parent_window = null);
+        static async void mount_volume_full (GLib.Volume volume, Gtk.Window? parent_window = null) throws GLib.Error;
+        static void trash_or_delete (GLib.List<GLib.File> locations, Gtk.Window window, DeleteCallback? callback = null);
+        static void @delete (GLib.List<GLib.File> locations, Gtk.Window window, DeleteCallback? callback = null);
+        static bool has_trash_files (GLib.Mount mount);
+        static GLib.List<GLib.File> get_trash_dirs_for_mount (GLib.Mount mount);
+        static void empty_trash (Gtk.Widget? widget);
+        static void empty_trash_for_mount (Gtk.Widget? widget, GLib.Mount mount);
+        static void copy_move_link (GLib.List<GLib.File> files, GLib.Array<Gdk.Point>? relative_item_points, GLib.File target_dir, Gdk.DragAction copy_action, Gtk.Widget? parent_view = null, CopyCallback? done_callback = null);
+        static void new_file (Gtk.Widget parent_view, Gdk.Point? target_point, string parent_dir, string? target_filename, string? initial_contents, int length, Marlin.CreateCallback? create_callback = null);
+        static void new_file_from_template (Gtk.Widget parent_view, Gdk.Point? target_point, GLib.File parent_dir, string? target_filename, GLib.File template, Marlin.CreateCallback? create_callback = null);
+    }
+
+    [CCode (cheader_filename = "marlin-file-operations.h")]
+    public delegate void CreateCallback (GLib.File? new_file);
+    [CCode (cheader_filename = "marlin-file-operations.h")]
+    public delegate void DeleteCallback (bool user_cancel);
+    [CCode (cname="GCallback")]
+    public delegate void CopyCallback ();
+}
+
+[CCode (cprefix = "EelGtk", lower_case_cprefix = "eel_gtk_window_", cheader_filename = "eel-gtk-extensions.h")]
+namespace EelGtk.Window {
+    public string get_geometry_string (Gtk.Window win);
+    public void set_initial_geometry_from_string (Gtk.Window win, string geometry, uint w, uint h, bool ignore_position, int left_offset, int top_offset);
+}
+
+[CCode (cprefix = "EelGtk", lower_case_cprefix = "eel_gtk_widget_", cheader_filename = "eel-gtk-extensions.h")]
+namespace EelGtk.Widget {
+    public Gdk.Screen get_screen ();
+}
+
+[CCode (cprefix = "Eel", lower_case_cprefix = "eel_")]
+namespace Eel {
+    [CCode (cheader_filename = "eel-string.h")]
+    public string? str_double_underscores (string? str);
+}
+
+[CCode (cprefix = "Marlin", lower_case_cprefix = "marlin_")]
+namespace Marlin
+{
+    [CCode (cheader_filename = "marlin-undostack-manager.h")]
+    public struct UndoMenuData {
+        string undo_label;
+        string undo_description;
+        string redo_label;
+        string redo_description;
+    }
+
+    [CCode (cheader_filename = "marlin-undostack-manager.h")]
+    public delegate void UndoFinishCallback ();
+
+    [CCode (cheader_filename = "marlin-undostack-manager.h")]
+    public class UndoManager : GLib.Object
+    {
+        public static unowned UndoManager instance ();
+
+        public signal void request_menu_update (UndoMenuData data);
+
+        public void undo (Gtk.Widget widget, UndoFinishCallback? cb);
+        public void redo (Gtk.Widget widget, UndoFinishCallback? cb);
+        public void add_rename_action (GLib.File renamed_file, string original_name);
+    }
+
+//    [CCode (cprefix = "MarlinConnectServer", lower_case_cprefix = "marlin_connect_server_")]
+//    namespace ConnectServer {
+//        [CCode (cheader_filename = "marlin-connect-server-dialog.h")]
+//        public class Dialog : Gtk.Dialog {
+//            public Dialog (Gtk.Window window);
+//            public async bool display_location_async (GLib.File location) throws GLib.Error;
+//            public async bool fill_details_async (GLib.MountOperation operation,
+//                                                 string default_user,
+//                                                 string default_domain,
+//                                                 GLib.AskPasswordFlags flags);
+//        }
+//    }
+}
+
+[CCode (cprefix = "MarlinFile", lower_case_cprefix = "marlin_file_", cheader_filename = "marlin-file-changes-queue.h")]
+namespace MarlinFile {
+    public void changes_queue_file_added (GLib.File location);
+    public void changes_queue_file_changed (GLib.File location);
+    public void changes_queue_file_removed (GLib.File location);
+    public void changes_queue_file_moved (GLib.File location);
+    public void changes_consume_changes (bool consume_all);
+}


### PR DESCRIPTION
Depends on #1.
Depends on https://github.com/elementary/files/pull/922.

Implements the standard DBus interface `org.freedesktop.portal.FileChooser` by re-targeting the Files code to be a shared library that can be used by both the main app and the file chooser.

You can test this branch by compiling the files branch then compiling this one. Then launching `systemctl --user start xdg-desktop-portal-pantheon.service` and in another terminal `GTK_USE_PORTAL=1 app`.

TODO:
- [x] Implement the skeleton of  `org.freedesktop.impl.portal.FileChooser`
- [x] Gtk is receiving corrrect responses from the portal
- [ ] Figure out how to correctly link with Files
- [ ] Support all / most variant options for the dialog
- [ ] Strip the dialog out of Files specific features (open in tab, open in app etc.)

![filechooser](https://user-images.githubusercontent.com/8205284/56087814-fe76ec00-5e72-11e9-9e4d-66b29f2cb15a.png)